### PR TITLE
[WIP] feat: Changes in management of layer dependencies and metapackage names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,4 +166,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/.layerapi2_dependencies
+++ b/.layerapi2_dependencies
@@ -1,0 +1,4 @@
+root@mfcom
+python3@mfcom
+monitoring@mfext
+#+python3_circus@mfext

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ MODULE_LOWERCASE=mfadmin
 -include $(MFEXT_HOME)/share/main_root.mk
 
 all:: directories
-	echo "root@mfcom" >$(MFADMIN_HOME)/.layerapi2_dependencies
 	cd adm && $(MAKE)
 	cd config && $(MAKE)
 	cd layers && $(MAKE)

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,7 +1,4 @@
 root@mfadmin
 monitoring@mfadmin
--devtools@mext
-python3@mfcom
--python3_devtools@mfext
-python3@mfadmin
--monitoring@mfext
+python@mfadmin
+default@mfcom

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,1 +1,1 @@
-default
+default@mfadmin

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -1,0 +1,2 @@
+python@mfcom
+python3@mfadmin

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,0 +1,1 @@
+python@mfadmin

--- a/layers/layer9_python/Makefile
+++ b/layers/layer9_python/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk


### PR DESCRIPTION
(only minimal and full)
Associated with changes in mfext _metwork.spec, this reduces the number of layers installed by default when installing mfadmin (only necessary mfext layers are installed)
Metapackage metwork-mfadmin-minimal only installs the necessary layers for mfadmin to work properly
Metapackage metwork-mfadmin or metwork-mfserv-full installs all mfadmin layers

linked to #26 (mfadmin part)