### PR TITLE
feat: replace MODULE* environment variables names by MFMODULE* (MODUL…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MODULE=MFADMIN
-MODULE_LOWERCASE=mfadmin
+MFMODULE=MFADMIN
+MFMODULE_LOWERCASE=mfadmin
 
 -include adm/root.mk
 -include $(MFEXT_HOME)/share/main_root.mk

--- a/adm/_force_grafana_admin_password.sh
+++ b/adm/_force_grafana_admin_password.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-"${MODULE_HOME}/opt/metrics/opt/grafana/bin/grafana-cli" -d admin reset-admin-password --config "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini" --homepath "${MODULE_HOME}/opt/metrics/opt/grafana" "${MFADMIN_GRAFANA_ADMIN_PASSWORD}"
+"${MFMODULE_HOME}/opt/metrics/opt/grafana/bin/grafana-cli" -d admin reset-admin-password --config "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini" --homepath "${MFMODULE_HOME}/opt/metrics/opt/grafana" "${MFADMIN_GRAFANA_ADMIN_PASSWORD}"

--- a/adm/_make_nginx_conf
+++ b/adm/_make_nginx_conf
@@ -2,4 +2,4 @@
 
 "${MFCOM_HOME}/bin/_make_nginx_conf"
 
-printf "admin:%s\\n" "$(openssl passwd -apr1 "${MFADMIN_KIBANA_ADMIN_PASSWORD}")" >"${MODULE_RUNTIME_HOME}/tmp/kibana.passwd"
+printf "admin:%s\\n" "$(openssl passwd -apr1 "${MFADMIN_KIBANA_ADMIN_PASSWORD}")" >"${MFMODULE_RUNTIME_HOME}/tmp/kibana.passwd"

--- a/adm/_provision_kibana_dashboards
+++ b/adm/_provision_kibana_dashboards
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for F in ${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards/*.json; do
+for F in ${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards/*.json; do
     cat "${F}" |import_kibana_dashboard.py
 done
 

--- a/adm/before_start_elasticsearch
+++ b/adm/before_start_elasticsearch
@@ -1,25 +1,25 @@
 #!/bin/bash
 
-mkdir -p "${MODULE_RUNTIME_HOME}/var/elasticsearch"
-rm -Rf "${MODULE_RUNTIME_HOME}/tmp/elasticsearch"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/elasticsearch"
-cp -Rf "${MODULE_HOME}/opt/logs/opt/elasticsearch/config" "${MODULE_RUNTIME_HOME}/tmp/elasticsearch"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/var/elasticsearch"
+rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch"
+cp -Rf "${MFMODULE_HOME}/opt/logs/opt/elasticsearch/config" "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch"
 for DIR in bin lib modules; do
-    ln -s "${MODULE_HOME}/opt/logs/opt/elasticsearch/${DIR}" "${MODULE_RUNTIME_HOME}/tmp/elasticsearch/${DIR}"
+    ln -s "${MFMODULE_HOME}/opt/logs/opt/elasticsearch/${DIR}" "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/${DIR}"
 done
 for DIR in plugins logs; do
-    mkdir -p "${MODULE_RUNTIME_HOME}/tmp/elasticsearch/${DIR}"
+    mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/${DIR}"
 done
-cat "${MODULE_HOME}/config/elasticsearch.conf" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config/elasticsearch.yml"
-cat "${MODULE_HOME}/config/elasticsearch_jvm_options.conf" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config/jvm.options"
-cat "${MODULE_HOME}/config/elasticsearch_log4j2_properties.conf" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config/log4j2.properties"
-rm -f "${MODULE_RUNTIME_HOME}/tmp/config_auto/elasticsearch"
-ln -s "${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config" "${MODULE_RUNTIME_HOME}/tmp/config_auto/elasticsearch"
+cat "${MFMODULE_HOME}/config/elasticsearch.conf" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config/elasticsearch.yml"
+cat "${MFMODULE_HOME}/config/elasticsearch_jvm_options.conf" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config/jvm.options"
+cat "${MFMODULE_HOME}/config/elasticsearch_log4j2_properties.conf" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config/log4j2.properties"
+rm -f "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/elasticsearch"
+ln -s "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config" "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/elasticsearch"
 
-export ES_PATH_CONF="${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/elasticsearch/tmp"
-export ES_TMPDIR="${MODULE_RUNTIME_HOME}/tmp/elasticsearch/tmp"
-if test -s "${MODULE_RUNTIME_HOME}/tmp/elasticsearch/config/elasticsearch.yml"; then
+export ES_PATH_CONF="${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/tmp"
+export ES_TMPDIR="${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/tmp"
+if test -s "${MFMODULE_RUNTIME_HOME}/tmp/elasticsearch/config/elasticsearch.yml"; then
     exit 0
 else
     exit 1

--- a/adm/before_start_grafana
+++ b/adm/before_start_grafana
@@ -1,29 +1,29 @@
 #!/bin/bash
 
-rm -Rf "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_dashboards"
-cp -r "${MODULE_HOME}/config/grafana_dashboards" "${MODULE_RUNTIME_HOME}/tmp/config_auto/"
+rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_dashboards"
+cp -r "${MFMODULE_HOME}/config/grafana_dashboards" "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/"
 if test -d /etc/metwork.config.d/mfadmin/grafana_dashboards; then
     N=$(ls /etc/metwork.config.d/mfadmin/grafana_dashboards 2>/dev/null |wc -l)
     if test "${N}" -gt 0; then
-        cp -f /etc/metwork.config.d/mfadmin/grafana_dashboards/* "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_dashboards/"
+        cp -f /etc/metwork.config.d/mfadmin/grafana_dashboards/* "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_dashboards/"
     fi
 fi
-rm -Rf "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/datasources"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/dashboards"
-cat "${MODULE_HOME}/config/grafana_provisioning/datasources/datasource.yaml" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/datasources/datasource.yaml"
-cat "${MODULE_HOME}/config/grafana_provisioning/dashboards/dashboard.yaml" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/dashboards/dashboard.yaml"
+rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/datasources"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/dashboards"
+cat "${MFMODULE_HOME}/config/grafana_provisioning/datasources/datasource.yaml" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/datasources/datasource.yaml"
+cat "${MFMODULE_HOME}/config/grafana_provisioning/dashboards/dashboard.yaml" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana_provisioning/dashboards/dashboard.yaml"
 
-cat "${MODULE_HOME}/config/grafana.ini" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini"
-
-
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/www"
-cat "${MODULE_HOME}/config/www/index.html" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/www/index.html"
-cat "${MODULE_HOME}/config/www/index.css" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/www/index.css"
-cp -rf "${MODULE_HOME}/config/www/images" "${MODULE_RUNTIME_HOME}/tmp/www/"
+cat "${MFMODULE_HOME}/config/grafana.ini" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini"
 
 
-if test -s "${MODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini"; then
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/www"
+cat "${MFMODULE_HOME}/config/www/index.html" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/www/index.html"
+cat "${MFMODULE_HOME}/config/www/index.css" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/www/index.css"
+cp -rf "${MFMODULE_HOME}/config/www/images" "${MFMODULE_RUNTIME_HOME}/tmp/www/"
+
+
+if test -s "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/grafana.ini"; then
     exit 0
 else
     exit 1

--- a/adm/before_start_influxdb
+++ b/adm/before_start_influxdb
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-mkdir -p ${MODULE_RUNTIME_HOME}/var/influxdb/meta
-mkdir -p ${MODULE_RUNTIME_HOME}/var/influxdb/data
-cat ${MODULE_HOME}/config/influxdb.conf |envtpl --reduce-multi-blank-lines >${MODULE_RUNTIME_HOME}/tmp/config_auto/influxdb.conf
-if test -s ${MODULE_RUNTIME_HOME}/tmp/config_auto/influxdb.conf; then
+mkdir -p ${MFMODULE_RUNTIME_HOME}/var/influxdb/meta
+mkdir -p ${MFMODULE_RUNTIME_HOME}/var/influxdb/data
+cat ${MFMODULE_HOME}/config/influxdb.conf |envtpl --reduce-multi-blank-lines >${MFMODULE_RUNTIME_HOME}/tmp/config_auto/influxdb.conf
+if test -s ${MFMODULE_RUNTIME_HOME}/tmp/config_auto/influxdb.conf; then
     exit 0
 else
     exit 1

--- a/adm/before_start_kibana
+++ b/adm/before_start_kibana
@@ -1,34 +1,34 @@
 #!/bin/bash
 
-mkdir -p "${MODULE_RUNTIME_HOME}/var/kibana"
-rm -Rf "${MODULE_RUNTIME_HOME}/tmp/kibana"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/kibana/optimize"
-rm -Rf "${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards"
-mkdir -p "${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards"
-cp -r "${MODULE_HOME}/config/kibana_dashboards" "${MODULE_RUNTIME_HOME}/tmp/config_auto/"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/var/kibana"
+rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/kibana"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/kibana/optimize"
+rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards"
+mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards"
+cp -r "${MFMODULE_HOME}/config/kibana_dashboards" "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/"
 if test -d /etc/metwork.config.d/mfadmin/kibana_dashboards; then
     N=$(ls /etc/metwork.config.d/mfadmin/kibana_dashboards 2>/dev/null |wc -l)
     if test "${N}" -gt 0; then
-        cp -f /etc/metwork.config.d/mfadmin/kibana_dashboards/* "${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards/"
+        cp -f /etc/metwork.config.d/mfadmin/kibana_dashboards/* "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana_dashboards/"
     fi
 fi
-cp -Rf "${MODULE_HOME}/opt/logs/opt/kibana/config" "${MODULE_RUNTIME_HOME}/tmp/kibana"
-cp -Rf "${MODULE_HOME}/opt/logs/opt/kibana/src" "${MODULE_RUNTIME_HOME}/tmp/kibana"
-cp -f "${MODULE_HOME}/opt/logs/opt/kibana/package.json" "${MODULE_RUNTIME_HOME}/tmp/kibana"
-cp -f "${MODULE_HOME}/opt/logs/opt/kibana/optimize/.babelcache.json" "${MODULE_RUNTIME_HOME}/tmp/kibana/optimize/"
+cp -Rf "${MFMODULE_HOME}/opt/logs/opt/kibana/config" "${MFMODULE_RUNTIME_HOME}/tmp/kibana"
+cp -Rf "${MFMODULE_HOME}/opt/logs/opt/kibana/src" "${MFMODULE_RUNTIME_HOME}/tmp/kibana"
+cp -f "${MFMODULE_HOME}/opt/logs/opt/kibana/package.json" "${MFMODULE_RUNTIME_HOME}/tmp/kibana"
+cp -f "${MFMODULE_HOME}/opt/logs/opt/kibana/optimize/.babelcache.json" "${MFMODULE_RUNTIME_HOME}/tmp/kibana/optimize/"
 for DIR in bin node node_modules optimize/bundles webpackShims; do
-    ln -s "${MODULE_HOME}/opt/logs/opt/kibana/${DIR}" "${MODULE_RUNTIME_HOME}/tmp/kibana/${DIR}"
+    ln -s "${MFMODULE_HOME}/opt/logs/opt/kibana/${DIR}" "${MFMODULE_RUNTIME_HOME}/tmp/kibana/${DIR}"
 done
 for DIR in plugins data; do
-    mkdir -p "${MODULE_RUNTIME_HOME}/tmp/kibana/${DIR}"
+    mkdir -p "${MFMODULE_RUNTIME_HOME}/tmp/kibana/${DIR}"
 done
 
-cat "${MODULE_HOME}/config/kibana.conf" |envtpl --reduce-multi-blank-lines >"${MODULE_RUNTIME_HOME}/tmp/kibana/config/kibana.yml"
-rm -f "${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana"
-ln -s "${MODULE_RUNTIME_HOME}/tmp/kibana/config" "${MODULE_RUNTIME_HOME}/tmp/config_auto/kibana"
+cat "${MFMODULE_HOME}/config/kibana.conf" |envtpl --reduce-multi-blank-lines >"${MFMODULE_RUNTIME_HOME}/tmp/kibana/config/kibana.yml"
+rm -f "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana"
+ln -s "${MFMODULE_RUNTIME_HOME}/tmp/kibana/config" "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/kibana"
 
-export KIBANA_HOME="${MODULE_RUNTIME_HOME}/tmp/kibana"
-if test -s "${MODULE_RUNTIME_HOME}/tmp/kibana/config/kibana.yml"; then
+export KIBANA_HOME="${MFMODULE_RUNTIME_HOME}/tmp/kibana"
+if test -s "${MFMODULE_RUNTIME_HOME}/tmp/kibana/config/kibana.yml"; then
     exit 0
 else
     exit 1

--- a/adm/mfxxx.init.custom
+++ b/adm/mfxxx.init.custom
@@ -3,16 +3,16 @@
 
 echo -n "- (pre)Starting mfadmin services..."
 echo_running
-mfadmin.start NOINIT >"${MODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$" 2>&1
+mfadmin.start NOINIT >"${MFMODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$" 2>&1
 mfadmin.status >/dev/null 2>&1
 if test $? -eq 0; then
     echo_ok
-    rm -f "${MODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
+    rm -f "${MFMODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
 else
     echo_nok
     echo_bold "=============== DEBUG OUTPUT =================================="
-    cat "${MODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
-    rm -f "${MODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
+    cat "${MFMODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
+    rm -f "${MFMODULE_RUNTIME_HOME}/tmp/mfadmin_start.$$"
     echo_bold "==============================================================="
     exit 1
 fi

--- a/config/Makefile
+++ b/config/Makefile
@@ -6,34 +6,34 @@ include $(MFCOM_HOME)/share/config_subdir.mk
 
 GRAFANA_DASHBOARDS=$(wildcard grafana_dashboards/*.json)
 KIBANA_DASHBOARDS=$(wildcard kibana_dashboards/*.json)
-TARGET_GRAFANA_DASHBOARDS=$(addprefix $(MODULE_HOME)/config/,$(GRAFANA_DASHBOARDS))
-TARGET_KIBANA_DASHBOARDS=$(addprefix $(MODULE_HOME)/config/,$(KIBANA_DASHBOARDS))
+TARGET_GRAFANA_DASHBOARDS=$(addprefix $(MFMODULE_HOME)/config/,$(GRAFANA_DASHBOARDS))
+TARGET_KIBANA_DASHBOARDS=$(addprefix $(MFMODULE_HOME)/config/,$(KIBANA_DASHBOARDS))
 
-all:: $(MODULE_HOME)/config/circus.ini $(MODULE_HOME)/config/telegraf.conf $(MODULE_HOME)/config/grafana_provisioning/datasources/datasource.yaml $(MODULE_HOME)/config/grafana_provisioning/dashboards/dashboard.yaml $(TARGET_GRAFANA_DASHBOARDS) $(TARGET_KIBANA_DASHBOARDS)
+all:: $(MFMODULE_HOME)/config/circus.ini $(MFMODULE_HOME)/config/telegraf.conf $(MFMODULE_HOME)/config/grafana_provisioning/datasources/datasource.yaml $(MFMODULE_HOME)/config/grafana_provisioning/dashboards/dashboard.yaml $(TARGET_GRAFANA_DASHBOARDS) $(TARGET_KIBANA_DASHBOARDS)
 
 # because of a problem with the subdir_root.mk default rule overriding
 $(PREFIX)/config/%: %
 
-$(MODULE_HOME)/config/%.ini: %.ini
+$(MFMODULE_HOME)/config/%.ini: %.ini
 	@mkdir -p $(shell dirname $@)
 	cp -f $< $@
 
-$(MODULE_HOME)/config/%.conf: %.conf
+$(MFMODULE_HOME)/config/%.conf: %.conf
 	@mkdir -p $(shell dirname $@)
 	cp -f $< $@
 
-$(MODULE_HOME)/config/grafana_dashboards/%.json: grafana_dashboards/%.json
-	@mkdir -p $(MODULE_HOME)/config/grafana_dashboards
+$(MFMODULE_HOME)/config/grafana_dashboards/%.json: grafana_dashboards/%.json
+	@mkdir -p $(MFMODULE_HOME)/config/grafana_dashboards
 	cat $< |sed 's/.{DS_INFLUXDB}/influxdb/g' |sed 's/DS_INFLUXDB/influxdb/g' >$@ || { rm -f $@ ; false ; }
 
-$(MODULE_HOME)/config/kibana_dashboards/%.json: kibana_dashboards/%.json
-	@mkdir -p $(MODULE_HOME)/config/kibana_dashboards
+$(MFMODULE_HOME)/config/kibana_dashboards/%.json: kibana_dashboards/%.json
+	@mkdir -p $(MFMODULE_HOME)/config/kibana_dashboards
 	cat $< |envtpl --reduce-multi-blank-lines >$@ || { rm -f $@ ; false ; }
 
-$(MODULE_HOME)/config/grafana_provisioning/datasources/datasource.yaml: grafana_provisioning/datasources/datasource.yaml
+$(MFMODULE_HOME)/config/grafana_provisioning/datasources/datasource.yaml: grafana_provisioning/datasources/datasource.yaml
 	mkdir -p `dirname $@`
 	cp -f $< $@
 
-$(MODULE_HOME)/config/grafana_provisioning/dashboards/dashboard.yaml: grafana_provisioning/dashboards/dashboard.yaml
+$(MFMODULE_HOME)/config/grafana_provisioning/dashboards/dashboard.yaml: grafana_provisioning/dashboards/dashboard.yaml
 	mkdir -p `dirname $@`
 	cp -f $< $@

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -5,89 +5,89 @@
 {% if MFADMIN_LAYER_METRICS_LOADED|default('0') == "1" %}
 [watcher:influxdb]
 cmd=influxd
-args=run -config {{MODULE_RUNTIME_HOME}}/tmp/config_auto/influxdb.conf
+args=run -config {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/influxdb.conf
 hooks.before_start=circus_hooks.before_start_shell
 hooks.after_start=circus_hooks.after_start_shell
 copy_env = True
 autostart = True
 respawn = True
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/influxdb.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/influxdb.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/influxdb.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/influxdb.log
 numprocesses=1
 
 [watcher:grafana]
 cmd={{MFADMIN_HOME}}/opt/metrics/opt/grafana/bin/grafana-server
-args=-config {{MODULE_RUNTIME_HOME}}/tmp/config_auto/grafana.ini -homepath {{MFADMIN_HOME}}/opt/metrics/opt/grafana --pidfile {{MODULE_RUNTIME_HOME}}/var/grafana.pid
+args=-config {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/grafana.ini -homepath {{MFADMIN_HOME}}/opt/metrics/opt/grafana --pidfile {{MFMODULE_RUNTIME_HOME}}/var/grafana.pid
 hooks.before_start=circus_hooks.before_start_shell
 copy_env = True
 autostart = True
 respawn = True
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/grafana.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/grafana.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/grafana.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/grafana.log
 numprocesses=1
 {% endif %}
 
 {% if MFADMIN_LAYER_LOGS_LOADED|default('0') == "1" %}
 [watcher:nginx]
 cmd={{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx
-args=-p {{MODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
+args=-p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log
 copy_env = True
 autostart = True
 respawn = True
 hooks.before_start=circus_hooks.before_start_shell
 hooks.after_stop=circus_hooks.after_stop_shell
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 async_kill = True
 
 [watcher:mflog2mfadmin]
 cmd=layer_wrapper
-args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func 127.0.0.1 {{MFADMIN_ELASTICSEARCH_HTTP_PORT}} mflog-%Y.%m.%d {{MODULE_RUNTIME_HOME}}/log/json_logs.log
+args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func 127.0.0.1 {{MFADMIN_ELASTICSEARCH_HTTP_PORT}} mflog-%Y.%m.%d {{MFMODULE_RUNTIME_HOME}}/log/json_logs.log
 numprocesses = 1
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_mflog.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_mflog.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_mflog.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_mflog.log
 copy_env = True
 autostart = True
 respawn = True
 hooks.before_start=circus_hooks.before_start_shell
 hooks.after_stop=circus_hooks.after_stop_shell
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 async_kill = True
 
 [watcher:elasticsearch]
-cmd={{MODULE_RUNTIME_HOME}}/tmp/elasticsearch/bin/elasticsearch
+cmd={{MFMODULE_RUNTIME_HOME}}/tmp/elasticsearch/bin/elasticsearch
 args=
 hooks.before_start=circus_hooks.before_start_shell
 copy_env = True
 autostart = True
 respawn = True
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/elasticsearch.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/elasticsearch.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/elasticsearch.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/elasticsearch.log
 numprocesses=1
 
 [watcher:kibana]
-cmd={{MODULE_RUNTIME_HOME}}/tmp/kibana/bin/kibana
-args=--config {{MODULE_RUNTIME_HOME}}/tmp/kibana/config/kibana.yml
+cmd={{MFMODULE_RUNTIME_HOME}}/tmp/kibana/bin/kibana
+args=--config {{MFMODULE_RUNTIME_HOME}}/tmp/kibana/config/kibana.yml
 hooks.before_start=circus_hooks.before_start_shell
 copy_env = True
 autostart = True
 respawn = True
 stdout_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/kibana.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/kibana.log
 stderr_stream.class = FileStream
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/kibana.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/kibana.log
 numprocesses=1
 {% endif %}
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -26,7 +26,7 @@ minimal_level[DEV]=DEBUG
 # duplicate some log messages in JSON to a specific file (for external monitoring tool)
 # If json_file value is:
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MODULE_RUNTIME_HOME@@@/log/json_logs.log if
+# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log if
 #         [admin]/hostname != null else null (desactivated)
 json_file=AUTO
 
@@ -46,8 +46,8 @@ json_minimal_level=WARNING
 [circus]
 
 # You don't have to change this
-endpoint=ipc://{{MODULE_RUNTIME_HOME}}/var/circus.socket
-pubsub_endpoint=ipc://{{MODULE_RUNTIME_HOME}}/var/circus_pubsub.socket
+endpoint=ipc://{{MFMODULE_RUNTIME_HOME}}/var/circus.socket
+pubsub_endpoint=ipc://{{MFMODULE_RUNTIME_HOME}}/var/circus_pubsub.socket
 
 
 ####################
@@ -154,4 +154,4 @@ timeout=60
 logging=0
 
 # In which tmp directory nginx put big request bodies
-clientbody_temp_path=@@@MODULE_RUNTIME_HOME@@@/var/nginx2
+clientbody_temp_path=@@@MFMODULE_RUNTIME_HOME@@@/var/nginx2

--- a/config/crontab.custom
+++ b/config/crontab.custom
@@ -3,6 +3,6 @@
 {% block custom %}
 {% raw %}
 # ElasticSearch cleaning
-30 3,9,15,21 * * * {{RUNTIME_SUFFIX}} {{MODULE_HOME}}/bin/cronwrap.sh --lock --low --timeout=3600 -- elasticsearch.clean >>{{MODULE_RUNTIME_HOME}}/log/elasticsearch_clean.log 2>&1
+30 3,9,15,21 * * * {{RUNTIME_SUFFIX}} {{MFMODULE_HOME}}/bin/cronwrap.sh --lock --low --timeout=3600 -- elasticsearch.clean >>{{MFMODULE_RUNTIME_HOME}}/log/elasticsearch_clean.log 2>&1
 {% endraw %}
 {% endblock %}

--- a/config/elasticsearch.conf
+++ b/config/elasticsearch.conf
@@ -1,7 +1,7 @@
 cluster.name: mfadmin
 node.name: {{MFADMIN_ELASTICSEARCH_NODE_NAME}}
-path.logs: {{MODULE_RUNTIME_HOME}}/log
-path.data: {{MODULE_RUNTIME_HOME}}/var/elasticsearch
+path.logs: {{MFMODULE_RUNTIME_HOME}}/log
+path.data: {{MFMODULE_RUNTIME_HOME}}/var/elasticsearch
 network.host: {{MFADMIN_ELASTICSEARCH_NETWORK_HOST}}
 http.port: {{MFADMIN_ELASTICSEARCH_HTTP_PORT}}
 discovery.type: single-node

--- a/config/grafana.ini
+++ b/config/grafana.ini
@@ -12,19 +12,19 @@ instance_name = {{MFCOM_HOSTNAME}}
 #################################### Paths ###############################
 [paths]
 # Path to where grafana can store temp files, sessions, and the sqlite3 db (if that is used)
-data = {{MODULE_RUNTIME_HOME}}/var/grafana
+data = {{MFMODULE_RUNTIME_HOME}}/var/grafana
 
 # Temporary files in `data` directory older than given duration will be removed
 temp_data_lifetime = 24h
 
 # Directory where grafana can store logs
-logs = {{MODULE_RUNTIME_HOME}}/log/grafana
+logs = {{MFMODULE_RUNTIME_HOME}}/log/grafana
 
 # Directory where grafana will automatically scan and look for plugins
 plugins = {{MFADMIN_HOME}}/opt/metrics/opt/grafana/plugins
 
 # folder that contains provisioning config files that grafana will apply on startup and while running.
-provisioning = {{MODULE_RUNTIME_HOME}}/tmp/config_auto/grafana_provisioning
+provisioning = {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/grafana_provisioning
 
 #################################### Server ##############################
 [server]

--- a/config/grafana_provisioning/dashboards/dashboard.yaml
+++ b/config/grafana_provisioning/dashboards/dashboard.yaml
@@ -8,4 +8,4 @@ providers:
   disableDeletion: false
   updateIntervalSeconds: 60
   options:
-    path: {{MODULE_RUNTIME_HOME}}/tmp/config_auto/grafana_dashboards
+    path: {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/grafana_dashboards

--- a/config/influxdb.conf
+++ b/config/influxdb.conf
@@ -23,7 +23,7 @@ bind-address = "127.0.0.1:{{MFADMIN_INFLUXDB_PORT}}"
 
 [meta]
   # Where the metadata/raft database is stored
-  dir = "{{MODULE_RUNTIME_HOME}}/var/influxdb/meta"
+  dir = "{{MFMODULE_RUNTIME_HOME}}/var/influxdb/meta"
 
   # Automatically create a default retention policy when creating a database.
   retention-autocreate = false
@@ -42,10 +42,10 @@ bind-address = "127.0.0.1:{{MFADMIN_INFLUXDB_PORT}}"
 
 [data]
   # The directory where the TSM storage engine stores TSM files.
-  dir = "{{MODULE_RUNTIME_HOME}}/var/influxdb/data"
+  dir = "{{MFMODULE_RUNTIME_HOME}}/var/influxdb/data"
 
   # The directory where the TSM storage engine stores WAL files.
-  wal-dir = "{{MODULE_RUNTIME_HOME}}/var/influxdb/wal"
+  wal-dir = "{{MFMODULE_RUNTIME_HOME}}/var/influxdb/wal"
 
   # The amount of time that a write will wait before fsyncing.  A duration
   # greater than 0 can be used to batch up multiple fsync calls.  This is useful for slower

--- a/config/kibana.conf
+++ b/config/kibana.conf
@@ -9,7 +9,7 @@ elasticsearch.url: "http://127.0.0.1:{{MFADMIN_ELASTICSEARCH_HTTP_PORT}}"
 #elasticsearch.logQueries: false
 
 # Specifies the path where Kibana creates the process ID file.
-pid.file: {{MODULE_RUNTIME_HOME}}/var/kibana.pid
+pid.file: {{MFMODULE_RUNTIME_HOME}}/var/kibana.pid
 
 # Enables you specify a file where Kibana stores log output.
 logging.dest: stdout
@@ -18,4 +18,4 @@ logging.dest: stdout
 # and all requests.
 #logging.verbose: false
 
-path.data: {{MODULE_RUNTIME_HOME}}/var/kibana
+path.data: {{MFMODULE_RUNTIME_HOME}}/var/kibana

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,11 +2,11 @@
 daemon off;
 worker_processes {{MFADMIN_NGINX_WORKERS}};
 {% if MFADMIN_LOG_MINIMAL_LEVEL == "DEBUG" %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
 {% else %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log error;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log error;
 {% endif %}
-pid        {{MODULE_RUNTIME_HOME}}/var/nginx.pid;
+pid        {{MFMODULE_RUNTIME_HOME}}/var/nginx.pid;
 
 # Main Loop Configuration
 events {
@@ -20,7 +20,7 @@ http {
     default_type  text/plain;
     # FIXME: ugly hack with ~~~1 and ~~~~2 to circumvent nginxfmt problem with JSON
     log_format main '~~~1 "@timestamp": "$time_iso8601", "from": "$remote_addr", "method": "$request_method", "uri": "$request_uri", "duration": $request_time, "status": $status, "request_length": $request_length, "reply_length": $bytes_sent ~~~2';
-    access_log  {{MODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
+    access_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
     client_body_temp_path {{MFADMIN_NGINX_CLIENTBODY_TEMP_PATH}};
     client_max_body_size {{MFADMIN_NGINX_UPLOAD_MAX_BODY_SIZE}}m;
     server_names_hash_bucket_size 1024;
@@ -79,11 +79,11 @@ http {
         location /kibana/ {
             proxy_pass http://127.0.0.1:{{MFADMIN_KIBANA_HTTP_PORT}}/;
             auth_basic "Restricted";
-            auth_basic_user_file {{MODULE_RUNTIME_HOME}}/tmp/kibana.passwd;
+            auth_basic_user_file {{MFMODULE_RUNTIME_HOME}}/tmp/kibana.passwd;
         }
 
         location / {
-        root {{MODULE_RUNTIME_HOME}}/share/www/;
+        root {{MFMODULE_RUNTIME_HOME}}/share/www/;
         index index.html;
     }
 

--- a/config/telegraf.conf.custom
+++ b/config/telegraf.conf.custom
@@ -10,12 +10,12 @@
   timeout = "10s"
 
 [[inputs.procstat]]
-  pattern = "influxd.run..config.{{MODULE_RUNTIME_HOME}}.tmp.config_auto.influxdb.conf"
-  user = "{{MODULE_RUNTIME_USER}}"
+  pattern = "influxd.run..config.{{MFMODULE_RUNTIME_HOME}}.tmp.config_auto.influxdb.conf"
+  user = "{{MFMODULE_RUNTIME_USER}}"
   process_name = "influxdb"
 
 [[inputs.filecount]]
-  directories = ["{{MODULE_RUNTIME_HOME}}/var/influxdb"]
+  directories = ["{{MFMODULE_RUNTIME_HOME}}/var/influxdb"]
   name = "*"
   recursive = true
   regular_only = true

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ def get_version():
     """
     :return: # The short X.Y version.
     """
-    return ".".join(os.environ.get('MODULE_VERSION',
+    return ".".join(os.environ.get('MFMODULE_VERSION',
                                    'unknown.unknown').split('.')[0:-1])
 
 
@@ -17,7 +17,7 @@ def get_release():
     """
     :return: the full version, including alpha/beta/rc tags
     """
-    return os.environ.get('MODULE_VERSION', 'unknown')
+    return os.environ.get('MFMODULE_VERSION', 'unknown')
 
 
 def build_intersphinx_mapping_url(current_module, module):

--- a/doc/mfadmin_monitoring_plugins.md
+++ b/doc/mfadmin_monitoring_plugins.md
@@ -58,7 +58,7 @@ send_mflog_logs=1
 # duplicate some log messages in JSON to a specific file (for external monitoring tool)
 # If json_file value is:
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MODULE_RUNTIME_HOME@@@/log/json_logs.log if
+# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log if
 #         [admin]/hostname != null else null (desactivated)
 json_file=AUTO
 

--- a/share/Makefile
+++ b/share/Makefile
@@ -2,13 +2,13 @@ include ../adm/root.mk
 include $(MFEXT_HOME)/share/subdir_root.mk
 include $(MFCOM_HOME)/share/config_subdir.mk
 
-TARGET_WWW=$(MODULE_HOME)/share/www
+TARGET_WWW=$(MFMODULE_HOME)/share/www
 
 all:: $(TARGET_WWW)
 
 clean::
 	rm -rf $(TARGET_WWW)
 
-$(MODULE_HOME)/share/www:
+$(MFMODULE_HOME)/share/www:
 	mkdir -p $@
 	cp -rf www/* $@


### PR DESCRIPTION
…E_HOME becomes MFMODULE_HOME and so on)

BREAKING CHANGE: old variables names are no longer defined, they should not be used anymore (be careful with existing plugins)