### PR TITLE
fix: security fix to block log4j security hole in elasticsearch

### DIFF
--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -45,6 +45,9 @@ autostart = False
 respawn = True
 numprocesses=1
 
+[env:elasticsearch]
+ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true
+
 [watcher:kibana]
 cmd=log_proxy_wrapper
 args=--stdout kibana.log --stderr STDOUT -- {{MFMODULE_RUNTIME_HOME}}/tmp/kibana/bin/kibana --config {{MFMODULE_RUNTIME_HOME}}/tmp/kibana/config/kibana.yml


### PR DESCRIPTION
See https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476