### PR TITLE
fix: create file kibana.passwd used by HTTP Basic Authentication for kibana access

### DIFF
--- a/adm/_make_nginx_conf
+++ b/adm/_make_nginx_conf
@@ -6,4 +6,7 @@ if test "${UUID}" = ""; then
 fi
 export UUID
 
+# make password file for kibana http basic authentication, cf. nginx.conf file
+printf "admin:%s\\n" "$(openssl passwd -apr1 "${MFADMIN_KIBANA_ADMIN_PASSWORD}")" >"${MFMODULE_RUNTIME_HOME}/tmp/kibana.passwd"
+
 cat "${MFMODULE_HOME}/config/nginx.conf" |envtpl --reduce-multi-blank-lines --search-paths=${MFADMIN_HOME}/config |sed 's/~~~1/{/g' |sed 's/~~~2/}/g' |grep -v 'FIXME: ugly hack'


### PR DESCRIPTION
another tiny but useful fix