### PR TITLE
fix: move kibana.passwd from ~/tmp to ~/var to prevent removal by crontab

### DIFF
--- a/adm/_make_nginx_conf
+++ b/adm/_make_nginx_conf
@@ -7,6 +7,6 @@ fi
 export UUID
 
 # make password file for kibana http basic authentication, cf. nginx.conf file
-printf "admin:%s\\n" "$(openssl passwd -apr1 "${MFADMIN_KIBANA_ADMIN_PASSWORD}")" >"${MFMODULE_RUNTIME_HOME}/tmp/kibana.passwd"
+printf "admin:%s\\n" "$(openssl passwd -apr1 "${MFADMIN_KIBANA_ADMIN_PASSWORD}")" >"${MFMODULE_RUNTIME_HOME}/var/kibana.passwd"
 
 cat "${MFMODULE_HOME}/config/nginx.conf" |envtpl --reduce-multi-blank-lines --search-paths=${MFADMIN_HOME}/config |sed 's/~~~1/{/g' |sed 's/~~~2/}/g' |grep -v 'FIXME: ugly hack'

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -92,7 +92,7 @@ http {
             {% endif %}
             proxy_pass http://127.0.0.1:{{MFADMIN_KIBANA_HTTP_PORT}}/;
             auth_basic "Restricted";
-            auth_basic_user_file {{MFMODULE_RUNTIME_HOME}}/tmp/kibana.passwd;
+            auth_basic_user_file {{MFMODULE_RUNTIME_HOME}}/var/kibana.passwd;
         }
 
         {% if MFADMIN_LDAP_FLAG == "1" %}


### PR DESCRIPTION
Closes #248