### PR TITLE
feat: add openjdk 11 for mfadmin (mfext now provides openjdk 21)

### DIFF
--- a/layers/layer0_java/.layerapi2_conflicts
+++ b/layers/layer0_java/.layerapi2_conflicts
@@ -1,0 +1,1 @@
+java@mfext

--- a/layers/layer0_java/.layerapi2_dependencies
+++ b/layers/layer0_java/.layerapi2_dependencies
@@ -1,3 +1,2 @@
 root@mfadmin
-java@mfadmin
 openresty@mfext

--- a/layers/layer0_java/.layerapi2_extra_env
+++ b/layers/layer0_java/.layerapi2_extra_env
@@ -1,0 +1,1 @@
+JAVA_HOME={MFADMIN_HOME}/opt/java

--- a/layers/layer0_java/.layerapi2_label
+++ b/layers/layer0_java/.layerapi2_label
@@ -1,0 +1,1 @@
+java@mfadmin

--- a/layers/layer0_java/0040_openjdk/Makefile
+++ b/layers/layer0_java/0040_openjdk/Makefile
@@ -1,0 +1,2 @@
+include ../../../adm/root.mk
+include $(MFEXT_HOME)/share/layer_wrapper.mk

--- a/layers/layer0_java/0040_openjdk/Makefile.mk
+++ b/layers/layer0_java/0040_openjdk/Makefile.mk
@@ -1,0 +1,20 @@
+include ../../../adm/root.mk
+include $(MFEXT_HOME)/share/package.mk
+
+#We will have to upgrade to 12.0.2 someday
+export NAME=openjdk
+export VERSION=11.0.5+10
+export EXTENSION=tar.gz
+export CHECKTYPE=MD5
+export CHECKSUM=b36a67900617c0f1b16511c0286dc5b7
+export ARCHIVE=OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz
+DESCRIPTION=\
+AdoptOpenJDK uses infrastructure, build and test scripts to produce prebuilt binaries from OpenJDK™ class libraries and a choice of either the OpenJDK HotSpot or Eclipse OpenJ9 VM.\
+All AdoptOpenJDK binaries and scripts are open source licensed and available for free.
+WEBSITE=https://adoptopenjdk.net
+LICENSE=GPL v2 with Classpath Exception (GPLv2+CE).
+
+all:: $(PREFIX)/bin/java
+$(PREFIX)/bin/java:
+	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) download uncompress
+	cd build/jdk-$(VERSION) && for DIR in bin conf demo include jmods legal lib man release; do rm -Rf $(PREFIX)/$${DIR}; cp -Rf $${DIR} $(PREFIX)/; done

--- a/layers/layer0_java/0040_openjdk/sources
+++ b/layers/layer0_java/0040_openjdk/sources
@@ -1,0 +1,1 @@
+https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz

--- a/layers/layer0_java/Makefile
+++ b/layers/layer0_java/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk

--- a/layers/layer0_java/layer_custom.md
+++ b/layers/layer0_java/layer_custom.md
@@ -1,0 +1,7 @@
+{% extends "layer.md" %}
+
+{% block overview %}
+
+The `layer0_java` layer contains an openjdk version compatible with layer1_logs (elasticsearch)
+
+{% endblock %}

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -3,6 +3,7 @@ python3@mfext
 -python3_devtools@mfext
 default@mfext
 -metrics@mfadmin
+-java@mfadmin
 -logs@mfadmin
 -logs_loki@mfadmin
 monitoring@mfext


### PR DESCRIPTION
To be done, try to upgrade :
- elasticsearch + bundled openjdk (since version 7)
- kibana
- grafana