### PR TITLE
fix: remove modules xpack-ml and repository-s3 from elasticsearch

### DIFF
--- a/layers/layer1_logs/0050_elasticsearch/Makefile.mk
+++ b/layers/layer1_logs/0050_elasticsearch/Makefile.mk
@@ -17,3 +17,10 @@ $(PREFIX)/opt/elasticsearch/bin/elasticsearch:
 	rm -Rf $(PREFIX)/opt/elasticsearch
 	mkdir -p $(PREFIX)/opt
 	cd build && cp -Rf $(NAME)-$(VERSION) $(PREFIX)/opt/elasticsearch
+	#Remove modules/x-pack-ml for a lighter rpm
+	rm -rf $(PREFIX)/opt/elasticsearch/modules/x-pack-ml
+	#Also remove modules/x-pack-esql and x-pack-esql-core (requiring x-pack-ml)
+	rm -rf $(PREFIX)/opt/elasticsearch/modules/x-pack-esql
+	rm -rf $(PREFIX)/opt/elasticsearch/modules/x-pack-esql-core
+	#Remove modules/repository-s3 generating errors
+	rm -rf $(PREFIX)/opt/elasticsearch/modules/repository-s3


### PR DESCRIPTION
(xpack-ml is big and useless and repository-s3 generate errors)