### PR TITLE
feat: bump python-multipart to 0.0.22 (fix high CVE-2026-24486)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -28,7 +28,7 @@
 | [pydantic](https://github.com/pydantic/pydantic) | 1.10.17 | ldap |
 | [PyJWT](https://github.com/jpadilla/pyjwt) | 2.4.0 | ldap |
 | [python-ldap](https://www.python-ldap.org/) | 3.4.5 | ldap |
-| [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.19 | ldap |
+| [python-multipart](https://github.com/Kludex/python-multipart) | 0.0.22 | ldap |
 | [redis](https://github.com/redis/redis-py) | 4.4.4 | ldap |
 | [setuptools-scm](https://github.com/pypa/setuptools_scm/) | 7.1.0 | ldap |
 | [sniffio](https://github.com/python-trio/sniffio) | 1.2.0 | ldap |

--- a/layers/layer3_ldap/0500_ldap_deps/requirements3.txt
+++ b/layers/layer3_ldap/0500_ldap_deps/requirements3.txt
@@ -20,7 +20,7 @@ pyasn1-modules==0.2.8
 pydantic==1.10.17
 PyJWT==2.4.0
 python-ldap==3.4.5
-python-multipart==0.0.19
+python-multipart==0.0.22
 redis==4.4.4
 setuptools-scm==7.1.0
 sniffio==1.2.0


### PR DESCRIPTION
Close: https://github.com/metwork-framework/mfadmin/security/dependabot/36